### PR TITLE
Enhance command execution in ProcessManager to correctly expand %CD% …

### DIFF
--- a/src/core/process_manager.py
+++ b/src/core/process_manager.py
@@ -29,7 +29,11 @@ class ProcessManager:
     def write(self, cmd):
         if self.process:
             if os.name == 'nt':
-                full_cmd = f"{cmd} & echo __CWD__:%CD%\n"
+                # Use cmd /c so %CD% is expanded in a child process after the user's
+                # command runs; otherwise %CD% is expanded at parse time and we get
+                # the previous directory (e.g. after "cd .." the display wouldn't update).
+                # Outer cmd: %%%% -> %% so inner receives %CD% and expands it to new cwd.
+                full_cmd = f'{cmd} & cmd /c "echo __CWD__:%%%%CD%%%%"\n'
             else:
                 full_cmd = f"{cmd}; echo __CWD__:$PWD\n"
             self.process.stdin.write(full_cmd)


### PR DESCRIPTION
…in Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue on Windows where the current working directory was not properly detected after executing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->